### PR TITLE
API 구현 (2) - 노래 좋아요 API 구현

### DIFF
--- a/api/src/main/java/com/example/songlikes/api/controller/AlbumController.java
+++ b/api/src/main/java/com/example/songlikes/api/controller/AlbumController.java
@@ -25,7 +25,7 @@ public class AlbumController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
-        log.info("앪범 수 조회 API 요청. release year: {}, artist: {}, page: {}, size: {}", releaseYear, artist, page, size);
+        log.info("앨범 수 조회 API 요청. release year: {}, artist: {}, page: {}, size: {}", releaseYear, artist, page, size);
         return albumCountService.searchAlbumCountByReleaseYearAndArtist(releaseYear, artist, page, size);
     }
 }

--- a/api/src/main/java/com/example/songlikes/api/controller/SongController.java
+++ b/api/src/main/java/com/example/songlikes/api/controller/SongController.java
@@ -1,0 +1,25 @@
+package com.example.songlikes.api.controller;
+
+import com.example.songlikes.api.service.SongLikeService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/songs")
+@RequiredArgsConstructor
+public class SongController {
+    private static final Logger log = LoggerFactory.getLogger(SongController.class);
+    private final SongLikeService songLikeService;
+
+    @PostMapping("/{songId}/likes")
+    public Mono<Boolean> likeSong(@PathVariable Long songId) {
+        log.info("노래 좋아요 증가 API 요청 songId: {}", songId);
+        return songLikeService.likeSong(songId);
+    }
+}

--- a/api/src/main/java/com/example/songlikes/api/service/SongLikeService.java
+++ b/api/src/main/java/com/example/songlikes/api/service/SongLikeService.java
@@ -1,0 +1,49 @@
+package com.example.songlikes.api.service;
+
+import com.example.songlikes.domain.entity.SongLikeHistory;
+import com.example.songlikes.domain.repository.SongLikeHistoryRepository;
+import com.example.songlikes.domain.repository.SongRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SongLikeService {
+    private static final Logger log = LoggerFactory.getLogger(SongLikeService.class);
+
+    private final SongRepository songRepository;
+    private final SongLikeHistoryRepository songLikeHistoryRepository;
+    private final TransactionalOperator transactionalOperator;
+
+    /**
+     * Song 의 likeCount 증가하고 SongLikeHistory 저장합니다.
+     *
+     * @param songId - 좋아요를 누른 Song 의 ID
+     * @return Mono<Boolean> - likeCount 증가 성공 여부
+     */
+    public Mono<Boolean> likeSong(Long songId) {
+        log.info("노래 좋아요 수 증가 songId: {}", songId);
+        // Song 의 likeCount 증가
+        return songRepository.increaseLikeCount(songId)
+            .flatMap(incremented -> {
+                if (incremented) {
+                    // SongLikeHistory 저장
+                    SongLikeHistory history = SongLikeHistory.builder()
+                        .songId(songId)
+                        .likedAt(LocalDateTime.now())
+                        .build();
+                    return songLikeHistoryRepository.save(history)
+                        .thenReturn(true);
+                } else {
+                    return Mono.just(false);
+                }
+            })
+            .as(transactionalOperator::transactional);
+    }
+}

--- a/api/src/main/java/com/example/songlikes/api/service/SongLikeService.java
+++ b/api/src/main/java/com/example/songlikes/api/service/SongLikeService.java
@@ -44,6 +44,16 @@ public class SongLikeService {
                     return Mono.just(false);
                 }
             })
-            .as(transactionalOperator::transactional);
+            .as(transactionalOperator::transactional)
+            .doOnSuccess(transactional -> {
+                if (transactional) {
+                    log.info("노래 좋아요 수 증가 성공 songId: {}", songId);
+                } else {
+                    log.warn("노래 좋아요 수 증가 실패 songId: {}", songId);
+                }
+            })
+            .doOnError(error -> {
+                log.error("노래 좋아요 수 증가 중 오류 발생 songId: {}, error: {}", songId, error.getMessage());
+            });
     }
 }

--- a/api/src/test/java/com/example/songlikes/api/controller/SongControllerTest.java
+++ b/api/src/test/java/com/example/songlikes/api/controller/SongControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.songlikes.api.controller;
+
+import com.example.songlikes.api.service.SongLikeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.*;
+
+@WebFluxTest(controllers = SongController.class)
+public class SongControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private SongLikeService songLikeService;
+
+    @Test
+    void songLike_success() {
+        // given
+        Long songId = 1L;
+        when(songLikeService.likeSong(songId)).thenReturn(Mono.just(true));
+
+        // when
+        webTestClient.post()
+            .uri("/api/songs/{songId}/likes", songId)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(Boolean.class)
+            .isEqualTo(true);
+
+        // verify service call
+        verify(songLikeService, times(1)).likeSong(songId);
+    }
+}

--- a/api/src/test/java/com/example/songlikes/api/service/SongLikeServiceTest.java
+++ b/api/src/test/java/com/example/songlikes/api/service/SongLikeServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.songlikes.api.service;
+
+import com.example.songlikes.domain.entity.SongLikeHistory;
+import com.example.songlikes.domain.repository.SongLikeHistoryRepository;
+import com.example.songlikes.domain.repository.SongRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class SongLikeServiceTest {
+    @Mock
+    private SongRepository songRepository;
+    @Mock
+    private SongLikeHistoryRepository songLikeHistoryRepository;
+    @Mock
+    private TransactionalOperator transactionalOperator;
+    @InjectMocks
+    private SongLikeService songLikeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testLikeSong_success() {
+        // Given
+        Long songId = 1L;
+        when(songRepository.increaseLikeCount(songId)).thenReturn(Mono.just(true));
+        when(songLikeHistoryRepository.save(any())).thenReturn(Mono.just(new SongLikeHistory()));
+        when(transactionalOperator.transactional(any(Mono.class))).thenAnswer(invocation -> {
+            Mono<Boolean> mono = invocation.getArgument(0);
+            return mono;
+        });
+
+        // When
+        ArgumentCaptor<SongLikeHistory> captor = ArgumentCaptor.forClass(SongLikeHistory.class);
+
+        StepVerifier.create(songLikeService.likeSong(songId))
+            .expectNext(true)
+            .verifyComplete();
+
+        // Then
+        verify(songRepository).increaseLikeCount(songId);
+        verify(songLikeHistoryRepository).save(captor.capture());
+        SongLikeHistory called = captor.getValue();
+        assert called.getSongId().equals(songId);
+
+        verify(transactionalOperator).transactional(any(Mono.class));
+    }
+
+    @Test
+    void testLikeSong_failure() {
+        // Given
+        Long songId = 2L;
+        when(songRepository.increaseLikeCount(songId)).thenReturn(Mono.just(false));
+        when(transactionalOperator.transactional(any(Mono.class))).thenAnswer(invocation -> {
+            Mono<Boolean> mono = invocation.getArgument(0);
+            return mono;
+        });
+
+        // When
+        StepVerifier.create(songLikeService.likeSong(songId))
+            .expectNext(false)
+            .verifyComplete();
+
+        // Then
+        verify(songRepository).increaseLikeCount(songId);
+        // verify SongLikeHistoryRepository is not called
+        verify(songLikeHistoryRepository, never()).save(any(SongLikeHistory.class));
+    }
+}

--- a/docker/initial_ddl.sql
+++ b/docker/initial_ddl.sql
@@ -53,3 +53,16 @@ ALTER TABLE songs
 CREATE INDEX idx_songs_artist_year_inc_album
     ON songs (artist, release_year)
     INCLUDE (album);
+
+-- songs 테이블에 좋아요 수를 저장하는 컬럼을 추가합니다.
+ALTER TABLE songs
+    ADD COLUMN like_count BIGINT DEFAULT 0;
+
+CREATE TABLE song_like_history
+(
+    id       BIGSERIAL PRIMARY KEY,
+    song_id  BIGINT,
+    liked_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_song_like_history_liked_at_song_id ON song_like_history (liked_at, song_id);

--- a/domain/src/main/java/com/example/songlikes/domain/entity/Song.java
+++ b/domain/src/main/java/com/example/songlikes/domain/entity/Song.java
@@ -62,4 +62,7 @@ public class Song {
     private String similarArtist3;
     private String similarSong3;
     private Double similarityScore3;
+
+    // 좋아요 수
+    private Long likeCount;
 }

--- a/domain/src/main/java/com/example/songlikes/domain/entity/SongLikeHistory.java
+++ b/domain/src/main/java/com/example/songlikes/domain/entity/SongLikeHistory.java
@@ -1,0 +1,22 @@
+package com.example.songlikes.domain.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "song_like_histories")
+public class SongLikeHistory {
+    @Id
+    private Long id;
+    // 좋아요를 누른 노래의 ID
+    private Long songId;
+    // 좋아요를 누른 시간
+    private LocalDateTime likedAt;
+}

--- a/domain/src/main/java/com/example/songlikes/domain/repository/SongLikeHistoryRepository.java
+++ b/domain/src/main/java/com/example/songlikes/domain/repository/SongLikeHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.songlikes.domain.repository;
+
+import com.example.songlikes.domain.entity.SongLikeHistory;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface SongLikeHistoryRepository extends ReactiveCrudRepository<SongLikeHistory, Long> {
+}

--- a/domain/src/main/java/com/example/songlikes/domain/repository/SongRepository.java
+++ b/domain/src/main/java/com/example/songlikes/domain/repository/SongRepository.java
@@ -1,7 +1,15 @@
 package com.example.songlikes.domain.repository;
 
 import com.example.songlikes.domain.entity.Song;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
 
 public interface SongRepository extends ReactiveCrudRepository<Song, Long>, SongRepositoryCustom {
+    @Modifying
+    @Query("UPDATE songs SET like_count = like_count + 1 WHERE id = :id")
+    Mono<Boolean> increaseLikeCount(@Param("id") Long songId);
 }

--- a/domain/src/test/java/com/example/songlikes/domain/repository/SongRepositoryIntegrationTest.java
+++ b/domain/src/test/java/com/example/songlikes/domain/repository/SongRepositoryIntegrationTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("test")
-public class SongRepositoryCustomIntegrationTest {
+public class SongRepositoryIntegrationTest {
 
     // region testcontainers 설정
     @Container
@@ -106,5 +106,36 @@ public class SongRepositoryCustomIntegrationTest {
         assert dto3.getReleaseYear() == 2021;
         assert dto3.getArtist().equals("IU");
         assert dto3.getAlbumCount() == 2;
+    }
+
+    @Test
+    void testIncreaseLikeCount() {
+        // Given
+        Song song = Song.builder()
+            .title("Test Song")
+            .artist("Test Artist")
+            .album("Test Album")
+            .releaseDate(LocalDate.of(2025, 1, 1))
+            .likeCount(100L)
+            .build();
+        Song savedSong = songRepository.save(song).block();
+
+        // When
+        boolean result = songRepository.increaseLikeCount(savedSong.getId()).block();
+
+        // Then
+        assert result;
+        Song updatedSong = songRepository.findById(savedSong.getId()).block();
+        assert updatedSong != null;
+        assert updatedSong.getLikeCount() == 101L;
+    }
+
+    @Test
+    void testIncreaseLikeCountNonExistentSong() {
+        // When
+        boolean result = songRepository.increaseLikeCount(999L).block();
+
+        // Then
+        assert !result;
     }
 }

--- a/domain/src/test/resources/schema/test_db_schema.sql
+++ b/domain/src/test/resources/schema/test_db_schema.sql
@@ -53,3 +53,16 @@ ALTER TABLE songs
 CREATE INDEX idx_songs_artist_year_inc_album
     ON songs (artist, release_year)
     INCLUDE (album);
+
+-- songs 테이블에 좋아요 수를 저장하는 컬럼을 추가합니다.
+ALTER TABLE songs
+    ADD COLUMN like_count BIGINT DEFAULT 0;
+
+CREATE TABLE song_like_history
+(
+    id       BIGSERIAL PRIMARY KEY,
+    song_id  BIGINT,
+    liked_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_song_like_history_liked_at_song_id ON song_like_history (liked_at, song_id);


### PR DESCRIPTION
- 노래에 대한 좋아요 수를 증가시키는 API 구현합니다.
- 좋아요 수를 트래킹하기 위해 Song 엔티티에 likeCount 필드 추가합니다.
- 좋아요 증가 API 호출 시, SongRepository 의 increaseLikeCount 메소드를 실행합니다.
  - 동시에 한곡에 대한 여러 좋아요 호출 시 동시성 이슈가 생길 수 있기 때문에, atomic 하게 증가시키기 위해 증가 쿼리를 호출합니다.
- 좋아요 증가 쿼리가 성공해서 true 를 반환하는 경우, SongLikeHistory 를 생성해 저장합니다.
  - 현재는 songId 와 likedAt 두 정보만 가지고 있습니다.
  - 추후 요구사항인 한시간 내 가장 많은 좋아요를 받은 노래 상위 10곡 조회에 사용하기 위함입니다.
- 좋아요 증가 쿼리와 SongLikeHistory 저장을 하나의 트랜잭션에서 처리를 하기 위해  TransactionalOperator 를 사용합니다.
- 성공적으로 좋아요 수 증가 와 히스토리 저장하면 true 를 반환합니다.